### PR TITLE
Eliminación Format (f) en runtime linea 263 y 284

### DIFF
--- a/03 - Control de flujo y ciclos.ipynb
+++ b/03 - Control de flujo y ciclos.ipynb
@@ -260,7 +260,7 @@
     "effort = None\n",
     "wants_to_pass_the_course = True\n",
     "if effort is None and wants_to_pass_the_course:\n",
-    "    raise RuntimeError(f\"there is not way you can pass the course without effort\")\n",
+    "    raise RuntimeError(\"there is not way you can pass the course without effort\")\n",
     "print(\"you can pass!\")"
    ]
   },
@@ -281,7 +281,7 @@
     "effort = 100\n",
     "wants_to_pass_the_course = True\n",
     "if effort is None and wants_to_pass_the_course:\n",
-    "    raise RuntimeError(f\"there is not way you can pass the course without effort\")\n",
+    "    raise RuntimeError(\"there is not way you can pass the course without effort\")\n",
     "print(\"you can pass!\")"
    ]
   },


### PR DESCRIPTION
Se elimina la 'f' que hace referencia a format en la linea 263 y 284, donde se hace un raise RuntimeError y en el string de salida no se tienen expresiones o variables para formatear, por lo que la letra f previa es innecesaria