### PR TITLE
Correcciones

### DIFF
--- a/05 - Funciones y Lambdas.ipynb
+++ b/05 - Funciones y Lambdas.ipynb
@@ -111,7 +111,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "tambien puedes asignar el valor del parámetro mientas llamas la función, esto algunas veces ayuda a que tu código sea más claro"
+    "También puedes asignar el valor del parámetro mientras llamas la función, esto algunas veces ayuda a que tu código sea más claro"
    ]
   },
   {


### PR DESCRIPTION
"tambien puedes asignar el valor del parámetro mientas..."

->

"También puedes asignar el valor del parámetro mientras..."