### PR TITLE
Informacion sobre PEP8 y comillas en strings

### DIFF
--- a/01 - Tipos de datos y operadores.ipynb
+++ b/01 - Tipos de datos y operadores.ipynb
@@ -437,7 +437,7 @@
     "\n",
     "En este punto ya usamos el concepto de variable, simplemente es una manera de referenciar los valores con los que se ejecuta un programa. La variable es un espacio en la memoria del computador (usualmente RAM), diferente del disco duro. Entre más variables uses, y más valores contengan esas, más RAM usas.\n",
     "\n",
-    "Las variables pueden escribirse con cualquier fomato (`comoEste` y `EsteOtro`), pero usualmente la comunidad de Python las escribe `en_el_formato_que_he_mostrado` y es bastante agradable seguir las convenciones cuando se habla de trabajo colaborativo; vale la pena mencionar, `esto` y `EstO` representan variables diferentes.\n",
+    "Las variables pueden escribirse con cualquier fomato (`comoEste` y `EsteOtro`), pero usualmente la comunidad de Python las escribe `en_el_formato_que_he_mostrado` y es bastante agradable seguir las convenciones cuando se habla de trabajo colaborativo; vale la pena mencionar, `esto` y `EstO` representan variables diferentes. Además, es importante saber que existe un estándar general de *estilo* para programar en python. En este se enmarca el nombramiento de variables, funciones, forma de identar, etc. Este estándar se llama [PEP8](https://www.python.org/dev/peps/pep-0008/).\n",
     "\n",
     "Finalmente, con respecto a las variables, nunca podrás usar una [palabra reservada de Pyhton](https://www.programiz.com/python-programming/keyword-list), pero también se recomiendan no usar nombres propios de tipos de datos the pyhton.\n",
     "\n",
@@ -740,19 +740,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "esto es una cadena de caracteres\n"
+      "esto es una cadena de caracteres\nesto también es una cadena de caracteres\nnotar cómo implementar \"comillas\" dobles como caracteres\nnotar cómo implementar 'comillas' simples como caracteres\n"
      ]
     }
    ],
    "source": [
-    "print(\"esto es una cadena de caracteres\")"
+    "print(\"esto es una cadena de caracteres\")\n",
+    "print('esto también es una cadena de caracteres')\n",
+    "print('notar cómo implementar \"comillas\" dobles como caracteres')\n",
+    "print(\"notar cómo implementar 'comillas' simples como caracteres\")"
    ]
   },
   {
@@ -995,7 +998,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.8.3-final"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Se añade información en el notebook 01 sobre PEP8 (en la parte en la que se habla de formas de nombramiento). Adicionalmente se añade un par de ejemplos de definición de cadena de caracteres para mostrar el uso de comillas simples y dobles en estas definiciones.