### PR TITLE
Fixed typo title

### DIFF
--- a/07 - Clases y objetos.ipynb
+++ b/07 - Clases y objetos.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Clases y objectos\n",
+    "# Clases y objetos\n",
     "\n",
     "Acá una explicación tomada de [Brilliant](https://brilliant.org/wiki/classes-oop/):\n",
     "\n",


### PR DESCRIPTION
Fixed typo: Cambiado "Objecto" por "Objeto" en título del principio en notebook 07